### PR TITLE
- aws-destination: do not validate the presence of keys, since they c…

### DIFF
--- a/packages/@datapull/aws-destination/index.js
+++ b/packages/@datapull/aws-destination/index.js
@@ -70,19 +70,6 @@ class AwsDestination {
         return resolve("Dry run");
       }
 
-      // validate the config
-      if (!this.config.accessKeyId) {
-        throw Error(`Destination API access key is empty`);
-      }
-
-      if (!this.config.secretAccessKey) {
-        throw Error(`Destination API secret key is empty`);
-      }
-
-      if (!this.config.region) {
-        return reject(`Destination region is not specified`);
-      }
-
       const sendToKinesis = (records) => {
         return new Promise((resolve, reject) => {
           console.log(`[AWS Destination] pushing ${params.Records.length} messages to aws (out of ${messages.length} total)`);

--- a/packages/@datapull/pipelines-scheduler/index.js
+++ b/packages/@datapull/pipelines-scheduler/index.js
@@ -12,7 +12,7 @@ class Scheduler {
 
   launch(pipelines) {
     if (this.config.runImmediately) {
-      this.run(pipelines);
+      return this.run(pipelines);
     }
 
     if (this.config.runEveryXMinutes) {
@@ -52,6 +52,8 @@ class Scheduler {
     limiter.on('dropped', (dropped) => {
       console.warn(`[Pipelines Scheduler] Pipeline is dropped in schedule "${this.scheduleName}"`, dropped);
     });
+
+    return limiter;
   }
 }
 


### PR DESCRIPTION
…an be set in the environment and not in the pipelines

- pipelines-scheduler: return bottleneck limiter instance, so that clients can subscribe to it's events