### PR TITLE
- aws-origin: support for detail calls that accept an arn from a pare…

### DIFF
--- a/examples/aws-test-ecs.yml
+++ b/examples/aws-test-ecs.yml
@@ -1,0 +1,66 @@
+name: aws-data
+
+description: Collects ECS instances
+
+configure-aws-accounts:
+  runner: json-config
+  items:
+    - acceptance:
+        accessKeyId: ${env.AWS_ACCOUNT1_K}
+        secretAccessKey: ${env.AWS_ACCOUNT1_S}
+        extendMessage:
+          account: "redapple.acceptance"
+
+configure-aws-regions:
+  runner: json-config
+  items:
+    - ireland:
+        region: eu-west-1
+        extendMessage:
+          region: eu-west-1
+
+collect-ecs-containerinstances:
+  runner: aws-origin.ECS.listClusters
+  awsDetailsCall:
+    itemsListKey: "clusterArns"
+    itemsAreStrings: true
+    method: ECS.listContainerInstances
+    keyParam: "cluster"
+    responseIsList: true
+  transform:
+    - jsonpath: $.*.containerInstanceArns.*
+  extendMessage:
+    resource: "aws.ecs.containerinstance"
+    resourceArn: ${JSON.parse(data)}
+
+collect-ecs-listServices:
+  runner: aws-origin.ECS.listClusters
+  awsDetailsCall:
+    itemsListKey: "clusterArns"
+    itemsAreStrings: true
+    method: ECS.listServices
+    keyParam: "cluster"
+    responseIsList: true
+  transform:
+    - jsonpath: $.*.serviceArns.*
+  extendMessage:
+    resource: "aws.ecs.service"
+    resourceArn: ${JSON.parse(data)}
+
+push-to-kinesis:
+  runner: aws-destination.Kinesis.putRecords
+  stream: "public-cloud-records"
+  accessKeyId: ${env.AWS_D_K}
+  secretAccessKey: ${env.AWS_D_S}
+  region: eu-west-1
+  partitionKey: "single-shard"
+
+  extendMessage:
+    _meta:
+      eventType: "public-cloud-records"
+      producedBy: "datapull.v1"
+      timestamp: ${pipeline.timestamp}
+    quantity: 1
+    period: ${pipeline.time.year}${pipeline.time.month}
+    details:
+      resourceArn: ${data}

--- a/packages/@datapull/aws-destination/index.js
+++ b/packages/@datapull/aws-destination/index.js
@@ -52,6 +52,8 @@ class AwsDestination {
       return Promise.resolve("No messages to push");
     }
 
+    console.log('[AWS Destination] ' + messages.length + ' message(s) to send');
+
     return new Promise((resolve, reject) => {
       const params = {};
 
@@ -63,7 +65,7 @@ class AwsDestination {
       }
 
       if (dryRun) {
-        console.log("[AwsDestination] Dry run: skipping sending messages");
+        console.log("[AWS Destination] Dry run: skipping sending messages.");
         params.Records.forEach(r => {
           console.log(r);
         });


### PR DESCRIPTION
…nt call as a parameter (example: ECS.listServices)

- aws-origin: support for detail calls that return list of objects in the response (example: ECS.listServices)
- aws-destination: additional output to the console